### PR TITLE
feat(ui): global max-width 700px and prevent background bleed

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -446,3 +446,21 @@ body { padding: 0 1rem; }
 .help-list{ display:grid; gap:12px; padding:12px 12px 0; }
 
 /* ‘알아두세요’ 패널은 이전에 추가한 규칙 재사용 */
+:root {
+  --page-max: 700px;
+}
+
+/* ★ 최대 가로폭 700px + 가운데 정렬 + 기본 여백 */
+.page-wrap {
+  max-width: var(--page-max);
+  margin: 0 auto;
+  padding: 12px;
+}
+
+/* ★ 배경 겹침 방지: body에 깔린 배경이미지/그라데이션 끄기 */
+body:has(.page-wrap) {
+  background-image: none !important;
+  background-repeat: no-repeat !important;
+  background-attachment: scroll !important;
+  background-color: #F7FAFC; /* 옅은 회청 톤 */
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,11 +1,20 @@
-import "../../styles/globals.css";
-import './globals.css';
-import { pretendard } from './fonts';
+// src/app/layout.js
+import "./globals.css";
+
+export const metadata = {
+  title: "2099-Trip",
+  description: "Travel helper",
+};
 
 export default function RootLayout({ children }) {
-	return (
-		<html lang='ko' className={pretendard.variable}>
-			<body>{children}</body>
-		</html>
-	);
+  return (
+    <html lang="ko">
+      <body>
+        {/* ★ 모든 페이지 공통 래퍼: 700px 캡 + 중앙정렬 */}
+        <main className="page-wrap">
+          {children}
+        </main>
+      </body>
+    </html>
+  );
 }


### PR DESCRIPTION
A. 전역 레이아웃 고정 (모든 페이지 공통)

최대 가로폭 700px + 중앙 정렬

src/app/layout.js: <main class="page-wrap"> 래퍼 적용

src/app/globals.css:

.page-wrap { max-width:700px; margin:0 auto; padding:12px; }


배경 겹침(중복 배경) 방지

body:has(.page-wrap) { background-image:none !important; }

.page-wrap 및 주요 래퍼에 background-image:none !important로 상위/전역 배경 비활성화

B. 긴급 도움(Help) 화면 폴리시/UX 폴리시 반영

헤더 톤: 연핑크 헤더 배경 + 아이콘 배경 + 타이틀 진한 빨강, 서브타이틀 진한 톤

탭 레일: 상단 그립(—) 제거, 탭은 연회색 박스 내부 + 선택 탭 민트 하이라이트

버튼 형태: 전화걸기/위치보기 사각형(rounded-8) 로 통일, 중앙 정렬

알아두세요 패널: 연노랑 박스 + 갈색 텍스트, 일본(JP) 특이값은 별도 안내 유지

현지 표현:

좌상단 번호 뱃지 스코프 수정 → 카드 내부에서만 번호가 보이도록 position 기준 고정

탭 클릭 시 왼쪽에 튀던 빨간 점 마커 제거

닫기 동작: “이 창만 닫힘” 원칙. 히스토리가 있으면 history.back(), 없으면 /sos로 이동

C. 로딩 가드 / 무한 로딩 방지

쿼리 파라미터 가드: c(country)나 city 없으면 즉시 안내 카드 + “처음으로” 버튼 노출 (무한 “불러오는 중…” 방지)

타임아웃 추가: loadPack()에 8초 AbortController 타임아웃 적용 → 실패 시 사용자에게 오류 메시지 표시

전화번호/주소 결측치 안전 처리: 전화번호 없으면 전화걸기 비활성/무동작, 주소 없으면 지도검색은 시설명만 검색

----------------------------------------------------------------------------------------------------------------------
src/app/layout.js — page-wrap 래퍼 추가

src/app/globals.css — 700px 캡, 중앙정렬, 전역 배경 겹침 방지

src/app/sos/help/page.jsx — 헤더/탭/버튼/알아두세요/로딩가드/타임아웃/닫기동작

src/app/sos/utils/loadPack.js — (옵션) fetch(url, {cache:"no-store", signal}) 지원